### PR TITLE
add step to determine the dev status

### DIFF
--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -27,7 +27,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-tinytex@v2
 

--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -60,6 +60,7 @@ jobs:
             echo 'dir=./docs/dev' >> $GITHUB_OUTPUT
           else
             echo 'dir=./docs' >> $GITHUB_OUTPUT
+          fi
       - name: Deploy PR preview to Netlify
         if: contains(env.isPush, 'false')
         id: netlify-deploy

--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -53,13 +53,19 @@ jobs:
           clean: false
           branch: gh-pages
           folder: docs
-
+      - id: deploy-dir 
+        name: Determine dev status
+        run: |
+          if [[ $(grep -c -E 'sion. ([0-9]*\.){3}' ${{ github.workspace }}/DESCRIPTION) == 1 ]]; then
+            echo 'dir=./docs/dev' >> $GITHUB_OUTPUT
+          else
+            echo 'dir=./docs' >> $GITHUB_OUTPUT
       - name: Deploy PR preview to Netlify
         if: contains(env.isPush, 'false')
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v2
         with:
-          publish-dir: './docs'
+          publish-dir: '${{ steps.deploy-dir.outputs.dir }}'
           production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message:

--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Deploy PR preview to Netlify
         if: contains(env.isPush, 'false')
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v2
+        uses: nwtgck/actions-netlify@v3
         with:
           publish-dir: '${{ steps.deploy-dir.outputs.dir }}'
           production-branch: main


### PR DESCRIPTION
This adds a step in pkgdown-netlify-preview that will determine the correct folder to use for the preview depending on the value of `Version:` in the DESCRIPTION file. 


This will fix #4 


NOTE: I have confirmation that it works in https://github.com/hubverse-org/hubDevs/pull/19#issuecomment-2387111172