### PR TITLE
Add GitHub workflows for publishing to PyPI and TestPyPI

### DIFF
--- a/publish-pypi-test/README.md
+++ b/publish-pypi-test/README.md
@@ -1,0 +1,11 @@
+# `publish-test-pypi`
+
+This workflow builds a Python package and publishes it to
+test.pypi.org whenever changes are pushed to the `main` branch.
+
+This workflow uses a trusted publisher when writing to TestPyPI, so there are a
+few one-time setup steps to complete before using it.
+
+See the Hubverse
+[Python release process documentation](https://hubverse.io/en/latest/developer/python.html#testpypi-setup)
+for more information.

--- a/publish-pypi-test/publish-pypi-test.yaml
+++ b/publish-pypi-test/publish-pypi-test.yaml
@@ -1,0 +1,64 @@
+# .github/workflows/publish-pypi-test.yaml
+# Uses trusted publishing to publish the package to TestPyPI as described here:
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# Before using, update the test.pypi url to reflect your package name:
+# https://test.pypi.org/p/<YOUR-PACKAGE-NAME>
+
+name: Publish to Test PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v5
+
+      - name: Install uv 🌟
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ">=0.0.1"
+
+      - name: Build package for distribution 🛠️
+        run: |
+          uv build
+
+      - name: Upload distribution packages 📤
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-distribution
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-test
+      url: https://test.pypi.org/p/<YOUR-PACKAGE-NAME>
+    permissions:
+       id-token: write  # needed for trusted publishing (i.e., OIDC)
+
+    steps:
+    - name: Download distribution artifacts 📥
+      uses: actions/download-artifact@v4
+      with:
+        name: package-distribution
+        path: dist/
+    - name: Publish distribution to TestPyPI 🚀
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/publish-pypi/README.md
+++ b/publish-pypi/README.md
@@ -1,0 +1,16 @@
+# `publish-pypi`
+
+This workflow is triggered by adding a release tag to a repository and does the
+following:
+
+- Builds a Python package
+- Publishes it to PyPI
+- Signs the Python distribution
+- Creates a GitHub release
+
+This workflow uses a trusted publisher when writing to PyPI, so there are a
+few one-time setup steps to complete before using it.
+
+See the Hubverse
+[Python release process documentation](https://hubverse.io/en/latest/developer/python.html#pypi-setup)
+for more information.

--- a/publish-pypi/publish-pypi.yaml
+++ b/publish-pypi/publish-pypi.yaml
@@ -1,0 +1,105 @@
+# .github/workflows/publish-pypi.yaml
+# Uses trusted publishing to publish the package to PyPI as described here:
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# Before using, update the pypi url to reflect your package name:
+# https://pypi.org/p/<YOUR-PACKAGE-NAME>
+
+name: Publish to PyPI and create GitHub release
+
+on:
+  push:
+    tags:
+      # only run workflow for tags in release format
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v5
+
+      - name: Install uv 🌟
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ">=0.0.1"
+
+      - name: Build package for distribution 🛠️
+        run: |
+          uv build
+
+      - name: Upload distribution packages 📤
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-distribution
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<YOUR-PACKAGE-NAME>
+    permissions:
+       id-token: write  # needed for trusted publishing (i.e., OIDC)
+
+    steps:
+    - name: Download distribution artifacts 📥
+      uses: actions/download-artifact@v4
+      with:
+        name: package-distribution
+        path: dist/
+    - name: Publish distribution to PyPI 🚀
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # required for creating GitHub Releases
+      id-token: write  # required for sigstore
+
+    steps:
+    - name: Download distribution artifacts 📥
+      uses: actions/download-artifact@v4
+      with:
+        name: package-distribution
+        path: dist/
+    - name: Sign the dists with Sigstore 📝
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release 🛠️
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+    - name: Upload artifact signatures to GitHub Release 📤
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Closes #7

These workflows mirror the ones successfully used when [publishing the Reich Lab's cladetime package](https://github.com/reichlab/cladetime/tree/main/.github/workflows).

This changeset makes the boilerplate more readily available to Hubverse devs (and gives us a place to link to when discussing the Python release process in hubDocs).