### PR TITLE
pkgdown-netlify-preview: add publish option to workflow dispatch

### DIFF
--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -8,6 +8,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish Site (uncheck for a dry run)"
+        type: boolean
+        required: false
+        default: true
 
 name: pkgdown-pr-preview
 
@@ -22,7 +28,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      isPush: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+      PUBLISH: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     permissions:
       contents: write
       pull-requests: write
@@ -47,7 +53,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy production to GitHub pages 🚀
-        if: contains(env.isPush, 'true')
+        if: contains(env.PUBLISH, 'true')
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false
@@ -62,7 +68,7 @@ jobs:
             echo 'dir=./docs' >> $GITHUB_OUTPUT
           fi
       - name: Deploy PR preview to Netlify
-        if: contains(env.isPush, 'false')
+        if: contains(env.PUBLISH, 'false')
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v3
         with:

--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -28,7 +28,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      PUBLISH: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+      PUBLISH: ${{ github.event_name == 'push' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This prevents publishing an in-process PR accidentally via the workflow dispatch

Ultimately, {pkgdown} controls what is published to prod [via `development: [mode: auto]`](https://pkgdown.r-lib.org/reference/build_site.html?q=dev#development-mode), but this prevents the development page from being updated until it's necessary. 


Note, this also adds another benefit: with this, it's possible to update the default site with typo fixes and other minor documentation fixes without having to create a new release. To do so, you would follow the hotfix release process to open a PR (without bumping the version number or NEWS) and then, once you and the reviewer are satisfied with the changes, you can run the `workflow_dispatch` from that branch and the main site will be updated. 