### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/publish-pypi-test/README.md
+++ b/publish-pypi-test/README.md
@@ -7,5 +7,5 @@ This workflow uses a trusted publisher when writing to TestPyPI, so there are a
 few one-time setup steps to complete before using it.
 
 See the Hubverse
-[Python release process documentation](https://hubverse.io/en/latest/developer/python.html#testpypi-setup)
+[Python release process documentation](https://docs.hubverse.io/en/latest/developer/python.html#testpypi-setup)
 for more information.

--- a/publish-pypi/README.md
+++ b/publish-pypi/README.md
@@ -12,5 +12,5 @@ This workflow uses a trusted publisher when writing to PyPI, so there are a
 few one-time setup steps to complete before using it.
 
 See the Hubverse
-[Python release process documentation](https://hubverse.io/en/latest/developer/python.html#pypi-setup)
+[Python release process documentation](https://docs.hubverse.io/en/latest/developer/python.html#pypi-setup)
 for more information.


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.