### PR TITLE
Implement tiered action pinning policy

### DIFF
--- a/.github/workflows/publish-codeql-pack.yaml
+++ b/.github/workflows/publish-codeql-pack.yaml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   packages: write
 
 jobs:
@@ -16,8 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+      - name: Set up CodeQL CLI
+        uses: github/codeql-action/setup-codeql@v3
 
       - name: Publish model pack
         run: codeql pack publish --dir codeql-model-pack/

--- a/.github/workflows/publish-codeql-pack.yaml
+++ b/.github/workflows/publish-codeql-pack.yaml
@@ -1,0 +1,25 @@
+name: Publish CodeQL model pack
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'codeql-model-pack/**'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+
+      - name: Publish model pack
+        run: codeql pack publish --dir codeql-model-pack/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,13 +5,68 @@
 
 > GitHub Actions for common hubverse developer CI tasks
 
-This repository stores [GitHub Actions](https://github.com/features/actions) for hubverse developers and packages, which can be used to do a variety of common hubverse developer CI tasks. 
+This repository stores [GitHub Actions](https://github.com/features/actions) for hubverse developers and packages, which can be used to do a variety of common hubverse developer CI tasks.
 
+## Workflows
 
-## Additional resources
+| Workflow | Language | Description |
+|----------|----------|-------------|
+| [`pkgdown-netlify-preview`](pkgdown-netlify-preview/) | R | Build pkgdown site, deploy production to GitHub Pages, deploy PR previews to Netlify |
+| [`publish-pypi`](publish-pypi/) | Python | Build, publish to PyPI via trusted publishing, sign with Sigstore, create GitHub release |
+| [`publish-pypi-test`](publish-pypi-test/) | Python | Build and publish to TestPyPI via trusted publishing |
 
-- [GitHub Actions for R](https://www.jimhester.com/talk/2020-rsc-github-actions/), Jim Hester's talk at rstudio::conf 2020. [Recording](https://resources.rstudio.com/rstudio-conf-2020/azure-pipelines-and-github-actions-jim-hester), [slidedeck](https://speakerdeck.com/jimhester/github-actions-for-r).
-- [GitHub Actions advent calendar](https://www.edwardthomson.com/blog/github_actions_advent_calendar.html) a series of blogposts by Edward Thomson, one of the GitHub Actions product managers
-  highlighting features of GitHub Actions.
-- [GitHub Actions with R](https://ropenscilabs.github.io/actions_sandbox/) - a short online book about using GitHub Actions with R, produced as part of the [rOpenSci OzUnconf](https://ozunconf19.ropensci.org/).
-- [Awesome Actions](https://github.com/sdras/awesome-actions#awesome-actions---) - a curated list of custom actions. **Note** that many of these are from early in the GitHub Actions beta and may no longer work.
+## Action pinning policy
+
+We use a tiered approach to pinning third-party GitHub Actions, balancing supply-chain security with maintenance burden. For the full security rationale, see the [hubverse security docs](https://docs.hubverse.io/en/latest/developer/security.html).
+
+### Tier 1 -- GitHub-official actions
+
+**Pin to: major version tag** (e.g., `@v5`)
+
+Actions under `actions/*` and `github/*`. Maintained by GitHub, verified publisher, extremely low supply-chain risk.
+
+Examples: `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact`
+
+### Tier 2 -- Trusted ecosystem actions
+
+**Pin to: major version tag** (e.g., `@v2`) **or latest exact version tag** if the project doesn't maintain rolling major tags.
+
+Actions from major, trusted organisations that are de facto standards in their ecosystem.
+
+| Action | Maintainer | Pin style |
+|--------|-----------|-----------|
+| `r-lib/actions/*` | Posit/tidyverse | `@v2` (rolling major tag) |
+| `astral-sh/setup-uv` | Astral | `@v7` (rolling major tag) |
+| `pypa/gh-action-pypi-publish` | Python Packaging Authority | `@v1.13.0` (exact version tag) |
+| `sigstore/gh-action-sigstore-python` | Sigstore / OpenSSF | `@v3.2.0` (exact version tag) |
+
+**Why some use exact version tags:** Not all trusted projects maintain rolling major version tags. `pypa/gh-action-pypi-publish` and `sigstore/gh-action-sigstore-python` only publish exact semver tags (e.g., `v1.13.0`, `v3.2.0`), so we pin to the latest version. Dependabot handles minor and major update PRs; patch updates are ignored (see below).
+
+### Tier 3 -- Other third-party actions
+
+**Pin to: full SHA** with a version comment (e.g., `@9d877eea...  #v4.7.6`)
+
+Actions from individual maintainers or smaller organisations where a compromised tag is a real risk.
+
+Examples: `JamesIves/github-pages-deploy-action`, `nwtgck/actions-netlify`
+
+### Dependabot configuration
+
+The dependabot config complements this policy:
+- **Patch updates ignored** for all actions (reduces noise for SHA-pinned and exact-version-pinned actions)
+- **Minor updates grouped** into single PRs
+- **Security alerts unaffected** -- dependabot security alerts are a separate system and will still fire for known CVEs regardless of version update settings
+
+### CodeQL trusted owners
+
+The `security-extended` CodeQL suite flags actions not pinned to SHA. To prevent false positives for Tier 2 actions, we maintain an org-level CodeQL model pack ([`codeql-model-pack/`](codeql-model-pack/)) that lists trusted action owners: `r-lib`, `astral-sh`, `pypa`, `sigstore`.
+
+The pack is automatically published to GitHub Container Registry as `hubverse-org/trusted-actions` whenever files in `codeql-model-pack/` are changed on `main` (via the [`publish-codeql-pack`](.github/workflows/publish-codeql-pack.yaml) workflow). It is referenced in the hubverse-org org-level CodeQL configuration so it applies to all repos.
+
+If a new action is promoted to Tier 2, add its owner to [`codeql-model-pack/models/trusted-actions-owners.yml`](codeql-model-pack/models/trusted-actions-owners.yml) and the pack will be republished automatically.
+
+### Adding a new third-party action
+
+For the process of evaluating and adding new third-party actions to hubverse workflows (including tier assessment, pinning method, and CodeQL/allowlist updates), see the [hubverse security docs](https://docs.hubverse.io/en/latest/developer/security.html).
+
+See [#18](https://github.com/hubverse-org/hubverse-developer-actions/issues/18) for the full discussion.

--- a/codeql-model-pack/models/trusted-actions-owners.yml
+++ b/codeql-model-pack/models/trusted-actions-owners.yml
@@ -1,0 +1,9 @@
+extensions:
+  - addsTo:
+      pack: codeql/actions-all
+      extensible: trustedActionsOwnerDataModel
+    data:
+      - ["r-lib"]
+      - ["astral-sh"]
+      - ["pypa"]
+      - ["sigstore"]

--- a/codeql-model-pack/qlpack.yml
+++ b/codeql-model-pack/qlpack.yml
@@ -1,0 +1,6 @@
+name: hubverse-org/trusted-actions
+version: 1.0.0
+library: true
+extensionTargets:
+  codeql/actions-all: ~0.4.0
+dataExtensions: models/**/*.yml

--- a/codeql-model-pack/qlpack.yml
+++ b/codeql-model-pack/qlpack.yml
@@ -3,4 +3,5 @@ version: 1.0.0
 library: true
 extensionTargets:
   codeql/actions-all: ~0.4.0
-dataExtensions: models/**/*.yml
+dataExtensions:
+  - models/**/*.yml

--- a/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
+++ b/pkgdown-netlify-preview/pkgdown-netlify-preview.yaml
@@ -33,17 +33,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  #v2.11.4
+      - uses: r-lib/actions/setup-tinytex@v2
 
-      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  #v2.11.4
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  #v2.11.4
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  #v2.11.4
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
@@ -54,7 +54,7 @@ jobs:
 
       - name: Deploy production to GitHub pages 🚀
         if: contains(env.PUBLISH, 'true')
-        uses: JamesIves/github-pages-deploy-action@9d877eea73427180ae43cf98e8914934fe157a1a  #v4.7.6
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  #v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/publish-pypi-test/publish-pypi-test.yaml
+++ b/publish-pypi-test/publish-pypi-test.yaml
@@ -18,16 +18,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python 🐍
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: ">=0.0.1"
 
@@ -36,7 +36,7 @@ jobs:
           uv build
 
       - name: Upload distribution packages 📤
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-distribution
           path: dist/
@@ -54,11 +54,11 @@ jobs:
 
     steps:
     - name: Download distribution artifacts 📥
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: package-distribution
         path: dist/
     - name: Publish distribution to TestPyPI 🚀
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/publish-pypi/publish-pypi.yaml
+++ b/publish-pypi/publish-pypi.yaml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python 🐍
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: ">=0.0.1"
 
@@ -37,7 +37,7 @@ jobs:
           uv build
 
       - name: Upload distribution packages 📤
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-distribution
           path: dist/
@@ -55,12 +55,12 @@ jobs:
 
     steps:
     - name: Download distribution artifacts 📥
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: package-distribution
         path: dist/
     - name: Publish distribution to PyPI 🚀
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.13.0
 
   github-release:
     name: >-
@@ -76,12 +76,12 @@ jobs:
 
     steps:
     - name: Download distribution artifacts 📥
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: package-distribution
         path: dist/
     - name: Sign the dists with Sigstore 📝
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@v3.2.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
## Summary

- Apply three-tier pinning policy to all workflow templates (see #18 for full discussion)
- Update all actions to latest versions
- Add CodeQL model pack (`codeql-model-pack/`) listing Tier 2 trusted owners (`r-lib`, `astral-sh`, `pypa`, `sigstore`) to prevent false positive unpinned-action alerts
- Add workflow to auto-publish model pack to GitHub Container Registry on changes
- Document tiered policy, CodeQL model pack, and new action onboarding process in README

## Action version changes

| Action | Tier | Before | After |
|--------|------|--------|-------|
| `actions/checkout` | 1 | `@v4`/`@v5` | `@v6` |
| `actions/setup-python` | 1 | `@v5` | `@v6` |
| `actions/upload-artifact` | 1 | `@v4` | `@v7` |
| `actions/download-artifact` | 1 | `@v4` | `@v8` |
| `r-lib/actions/*` | 2 | `@6f6e5b...` (v2.11.4) | `@v2` |
| `astral-sh/setup-uv` | 2 | `@v5` | `@v7` |
| `pypa/gh-action-pypi-publish` | 2 | `@release/v1` | `@v1.13.0` |
| `sigstore/gh-action-sigstore-python` | 2 | `@v3.0.0` | `@v3.2.0` |
| `JamesIves/github-pages-deploy-action` | 3 | `@9d877e...` (v4.7.6) | `@d92aa23...` (v4.8.0) |
| `nwtgck/actions-netlify` | 3 | `@4cbaf4...` (v3.0.0) | no change |

## After merging

1. Verify the `publish-codeql-pack` workflow runs successfully and the pack appears in org packages
2. Add `hubverse-org/trusted-actions` to org-level CodeQL config (Settings > Advanced Security > Global settings > Code scanning)
3. Proceed with Phase 3 (downstream rollout) and Phase 4 (hubDocs updates) per the [implementation plan](#issuecomment-4038156295)

## Test plan

- [x] Verify workflow YAML syntax is valid
- [ ] Verify `publish-codeql-pack` workflow triggers on merge
- [ ] Verify model pack publishes to GHCR successfully
- [ ] After adding to org config, verify no false positive unpinned-action alerts in a test repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)